### PR TITLE
use "check_mode: no" so the role can be run in check mode without errors.

### DIFF
--- a/tasks/sapnote/2526952.yml
+++ b/tasks/sapnote/2526952.yml
@@ -13,6 +13,7 @@
 
 - name: Show active tuned profile
   command: bash -lc "/usr/sbin/tuned-adm active | awk '/:/{print $NF}'"
+  check_mode: no
   register: current_profile
   changed_when: false
 - debug:


### PR DESCRIPTION
…mode